### PR TITLE
Trying to get it to work on 0.14, but it doesn't work yet

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -35,6 +35,7 @@ local checksPerFrame = conf and conf.checksPerFrame or 10
 
 local target = require("target")
 
+-- FIXME: it's currently crashing on this line, arg[0] is empty
 if not arg[0] then error("arg[0] missing-- this is impossible, something is wrong with this copy of lovr") end
 if not target then error("Please specify a project for lodr to run on the command line") end
 
@@ -193,7 +194,8 @@ else
 			tryMount()
 			if hasMain then
 				lastTimeRollover = nil
-				event.quit("restart")
+				-- FIXME: think this is how it should look like now, but haven't been able to test
+				event.restart()
 			else
 				lastTimeRollover = getTime
 				resetMessage()

--- a/target.lua
+++ b/target.lua
@@ -1,7 +1,7 @@
 if lovr.getOS() == "Android" then
-	local appId = lovr.filesystem.getApplicationId()
-	if not appId then error("Failed to get the Android application ID of the loader app") end
-	return "/sdcard/Android/data/"..appId.."/files/.lodr"
+	local appDataDir = lovr.filesystem.getAppdataDirectory()
+	if not appDataDir then error("Failed to get the Android application data directory of the loader app") end
+	return appDataDir .. "/.lodr"
 else
 	return arg[1]
 end


### PR DESCRIPTION
It's crashing because `arg[0]` is empty right now, which I'm confused about.

Although it should be said I did not use https://github.com/mcclure/lovr-oculus-mobile. Does that repo work with 0.14? I did not try, I just assumed it didn't but maybe that's my fault. Instead I followed the [compilation instructions in the LÖVR docs for Android/CMake](https://lovr.org/docs/Compiling) and added the LODR files.